### PR TITLE
動画ファイル添付時にvideo構文へリレーされるよう拡張子取得を対応

### DIFF
--- a/js/edit.js
+++ b/js/edit.js
@@ -507,7 +507,7 @@ function upload_files_insert(data, opt) {
 	let files = [];
 	for(var i=0; i<ary.length; i++) {
 		let file = ary[i];
-		let reg  = name.match(/\.(\w+)$/);
+		let reg  = file.name.match(/\.(\w+)$/);
 		let ext  = reg ? reg[1] : '';
 		files.push({
 			folder: opt.folder,


### PR DESCRIPTION
## 概要

ファイル添付時に未定義の変数`name`を参照していたため、ファイル名から拡張子を取得できず、記事へのファイル添付時に生成される`file`構文に拡張子が自動で付与されない状態となっていました。

このため本PRでは`file.name`からファイル名を取得することで、拡張子の自動取得と構文への反映ができるようにしています。

## 修正内容

ファイル添付時の拡張子取得処理を修正し、添付ファイルの拡張子が`file`構文に設定されるようにしました。

これにより、動画ファイル添付時に`file`構文から`video`構文へのリレーが機能し、動画が表示されるようになります。

## 修正前後での生成文字列

以下は修正前後でのファイル添付時に自動生成される文字列の比較です。

|  | 生成される文字列 |
| - | - |
| **修正前** | `[file::adiary/2026/:hoge.mp4:hoge.mp4]` | 
| **修正後** | `[file:mp4:adiary/2026/:hoge.mp4:hoge.mp4]` |

## 確認内容

Windows 11 Pro バージョン 25H2 (OSビルド 26200.8655)のMicrosoft Edge バージョン 149.0.4022.80で以下の動作を確認しています。

- `.mp4`ファイル添付時に`file`構文の第一引数[^1]に拡張子`mp4`が付与されること
- 拡張子付きの`file`構文から`video`構文へのリレーが機能し、動画が表示されること

[^1]: ここでの第一引数とは記法タグで`[tagname:param1:param2:param3]`とした場合の`param1`を指す

## ライセンス

adiaryのライセンスに準じますが、もし不都合であれば適当に解釈していただければと思います。